### PR TITLE
ナビゲーションとプロフィールのcssを変更

### DIFF
--- a/public/css/navigation.css
+++ b/public/css/navigation.css
@@ -1,0 +1,45 @@
+body {
+  font-family: "Helvetica Neue",
+    Arial,
+    "Hiragino Kaku Gothic ProN",
+    "Hiragino Sans",
+    Meiryo,
+    sans-serif;
+}
+a:visited{
+    color:blue;
+}
+.nav{
+    background: #145AC3;
+    padding:0;
+}
+.nav-top{
+    display:flex;   
+    justify-content:space-between;
+    align-items: center;
+}
+.nameplate{
+    background:#FFDBC9;
+    height:48px;
+    width:400px;
+    text-align:center;
+    font-size:32px;
+}
+.logo{
+    width:64px;
+    height:64px;
+}
+#logout-btn{
+    width:160px;
+    height:32px;
+    font-size: 24px;
+}
+.link{
+    width: auto;
+    font-size: 32px;
+}
+.link-btn{
+    width:160px;
+    height:48px;
+    cursor: pointer;
+}

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,5 +1,13 @@
+body {
+  font-family: "Helvetica Neue",
+    Arial,
+    "Hiragino Kaku Gothic ProN",
+    "Hiragino Sans",
+    Meiryo,
+    sans-serif;
+}
+
 .deck_table{
     border: 1px solid #000;
     background-color: #cdefff;
 }
-.

--- a/resources/views/deck/newdeck.blade.php
+++ b/resources/views/deck/newdeck.blade.php
@@ -2,6 +2,9 @@
     <x-slot name="title">
         Re_M New Deck
     </x-slot>
+    <x-slot name="stylesheet">
+        style.css
+    </x-slot>
     <x-slot name="header">
         Re_M 新しいデッキを作る
     </x-slot>

--- a/resources/views/deck/search.blade.php
+++ b/resources/views/deck/search.blade.php
@@ -1,9 +1,9 @@
 <x-app-layout>
-    <x-slot name="stylesheet">
-        "style.css"
-    </x-slot>
     <x-slot name="title">
         Re_M デッキ一覧
+    </x-slot>
+    <x-slot name="stylesheet">
+        style.css
     </x-slot>
     <x-slot name="header">
         Re_M デッキ一覧

--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -1,6 +1,10 @@
+<!--route='user.home'-->
 <x-app-layout>
     <x-slot name="title">
         Re_M ホーム
+    </x-slot>
+    <x-slot name="stylesheet">
+        style.css
     </x-slot>
     <x-slot name="header">
         Re_M ホーム

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -4,25 +4,19 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="csrf-token" content="{{ csrf_token() }}">
-        <link rel="stylesheet" href="{{ asset($stylesheet) }}">
-
         <title>{{ $title }}</title>
-
-        <!-- Fonts -->
-        <link rel="preconnect" href="https://fonts.bunny.net">
-        <!--<link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />-->
-
-        <!-- Scripts -->
-        <!--@vite(['resources/css/app.css', 'resources/js/app.js'])-->
+        <link rel="stylesheet" href='{{ asset("/css/" . "$stylesheet") }}'>
+        <!--Breezeのスクリプトのみ許可-->
+        @vite(['resources/js/app.js'])
     </head>
-    <body class="font-sans antialiased">
-        <div class="min-h-screen bg-blue-500">
+    <body class>
+        <div>
             @include('layouts.navigation')
 
             <!-- Page Heading -->
             @if (isset($header))
-                <header class="bg-white shadow">
-                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+                <header>
+                    <div>
                         {{ $header }}
                     </div>
                 </header>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,107 +1,37 @@
-<link rel="stylesheet" href="{{ asset(css/navigation.css) }}">
+<link rel="stylesheet" href="{{ asset('css/navigation.css') }}">
 <nav x-data="{ open: false }" class="bg-blue-500 border-b border-blue-500">
-    <!-- Primary Navigation Menu -->
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
-            <div class="flex">
-                <!-- Logo -->
-                <div class="shrink-0 flex items-center">
-                    <a href="{{ route('dashboard') }}">
-                        <x-application-logo class="block h-5 w-auto fill-current text-gray-800" />
-                    </a>
-                </div>
-
-                <!-- Navigation Links -->
-                <div class="hidden space-x-8 sm:-my-px sm:ml-10 sm:flex">
-                    <x-nav-link :href="route('user.home')" :active="request()->routeIs('user.home')">
-                        {{ __('Home') }}
-                    </x-nav-link>
-                    <x-nav-link :href="route('deck.newdeck')" :active="request()->routeIs('deck.newdeck')">
-                        {{ __('新しいデッキ') }}
-                    </x-nav-link>
-                    <x-nav-link :href="route('deck.search')" :active="request()->routeIs('deck.search')">
-                        {{ __('デッキ一覧') }}
-                    </x-nav-link>
-                </div>
+    <!-- ナビゲーションメニュー -->
+    <div class="nav">
+        <div class="nav-top">
+            <!--ロゴの表示 -->
+            <div class="logo-space">
+                <a href="{{ route('user.home') }}">
+                    <img src="{{ asset('/logo/Re_M_Logo.png') }}" class="logo">
+                </a>
             </div>
-
-            <!-- Settings Dropdown -->
-            <div class="hidden sm:flex sm:items-center sm:ml-6">
-                <x-dropdown align="right" width="48">
-                    <x-slot name="trigger">
-                        <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
-                            <div>{{ Auth::user()->name }}</div>
-
-                            <div class="ml-1">
-                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                </svg>
-                            </div>
-                        </button>
-                    </x-slot>
-
-                    <x-slot name="content">
-                        <x-dropdown-link :href="route('profile.edit')">
-                            {{ __('Profile') }}
-                        </x-dropdown-link>
-
-                        <!-- Authentication -->
-                        <form method="POST" action="{{ route('logout') }}">
-                            @csrf
-
-                            <x-dropdown-link :href="route('logout')"
-                                    onclick="event.preventDefault();
-                                                this.closest('form').submit();">
-                                {{ __('Log Out') }}
-                            </x-dropdown-link>
-                        </form>
-                    </x-slot>
-                </x-dropdown>
+            <!--名前の表示-->
+            <div class="nameplate">
+                ようこそ<a href="{{ route('profile.edit') }}">{{ Auth::user()->name }}</a>さん
             </div>
-
-            <!-- Hamburger -->
-            <div class="-mr-2 flex items-center sm:hidden">
-                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
-                    <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
-        <div class="pt-2 pb-3 space-y-1">
-            <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link>
-        </div>
-
-        <!-- Responsive Settings Options -->
-        <div class="pt-4 pb-1 border-t border-gray-200">
-            <div class="px-4">
-                <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-                <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
-            </div>
-
-            <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('profile.edit')">
-                    {{ __('Profile') }}
-                </x-responsive-nav-link>
-
-                <!-- Authentication -->
+            <div>
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf
-
-                    <x-responsive-nav-link :href="route('logout')"
+                    <x-dropdown-link :href="route('logout')"
                             onclick="event.preventDefault();
                                         this.closest('form').submit();">
-                        {{ __('Log Out') }}
-                    </x-responsive-nav-link>
+                        <button id="logout-btn">ログアウト</button> 
+                    </x-dropdown-link>
                 </form>
             </div>
+        </div>
+        <!--各リンク -->
+        <div class=link-space>
+            <a href="{{ route('deck.newdeck')}}">
+                <button class="link-btn">新しいデッキ</button>
+            </a>
+            <a href="{{ route('deck.search')}}">
+                <button class="link-btn">デッキ一覧</button>
+            </a>
         </div>
     </div>
 </nav>

--- a/resources/views/profile/edit.blade.php
+++ b/resources/views/profile/edit.blade.php
@@ -2,12 +2,14 @@
     <x-slot name="title">
         Re_M プロファイル
     </x-slot>
+    <x-slot name="stylesheet">
+        profile.css
+    </x-slot>
     <x-slot name="header">
         <h2 class="font-semibold text-xl text-gray-800 leading-tight">
             {{ __('Profile') }}
         </h2>
     </x-slot>
-
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
             <div class="p-4 sm:p-8 bg-white shadow sm:rounded-lg">

--- a/resources/views/profile/partials/delete-user-form.blade.php
+++ b/resources/views/profile/partials/delete-user-form.blade.php
@@ -1,30 +1,32 @@
 <section class="space-y-6">
     <header>
-        <h2 class="text-lg font-medium text-gray-900">
-            {{ __('Delete Account') }}
+        <h2>
+            アカウントの削除
         </h2>
 
         <p class="mt-1 text-sm text-gray-600">
-            {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Before deleting your account, please download any data or information that you wish to retain.') }}
+            一度アカウントを削除すると、アカウントに紐づいたあらゆるデータが永久に削除されます。</br>
+            必要なデータはダウンロードを済ませておいてください。
         </p>
     </header>
 
     <x-danger-button
         x-data=""
         x-on:click.prevent="$dispatch('open-modal', 'confirm-user-deletion')"
-    >{{ __('Delete Account') }}</x-danger-button>
+    >アカウントを削除</x-danger-button>
 
     <x-modal name="confirm-user-deletion" :show="$errors->userDeletion->isNotEmpty()" focusable>
         <form method="post" action="{{ route('profile.destroy') }}" class="p-6">
             @csrf
             @method('delete')
 
-            <h2 class="text-lg font-medium text-gray-900">
-                {{ __('Are you sure you want to delete your account?') }}
+            <h2>
+                本当にアカウントを削除しますか？
             </h2>
 
-            <p class="mt-1 text-sm text-gray-600">
-                {{ __('Once your account is deleted, all of its resources and data will be permanently deleted. Please enter your password to confirm you would like to permanently delete your account.') }}
+            <p>
+                一度アカウントを削除すると、アカウントに紐づいたあらゆるデータが永久に削除されます。</br>
+                それでも宜しければ、アカウントのパスワードを入力してください。
             </p>
 
             <div class="mt-6">
@@ -35,7 +37,7 @@
                     name="password"
                     type="password"
                     class="mt-1 block w-3/4"
-                    placeholder="{{ __('Password') }}"
+                    placeholder="アカウントのパスワード"
                 />
 
                 <x-input-error :messages="$errors->userDeletion->get('password')" class="mt-2" />
@@ -43,11 +45,10 @@
 
             <div class="mt-6 flex justify-end">
                 <x-secondary-button x-on:click="$dispatch('close')">
-                    {{ __('Cancel') }}
+                    キャンセル
                 </x-secondary-button>
-
-                <x-danger-button class="ml-3">
-                    {{ __('Delete Account') }}
+                <x-danger-button>
+                    アカウントを削除
                 </x-danger-button>
             </div>
         </form>

--- a/resources/views/profile/partials/update-password-form.blade.php
+++ b/resources/views/profile/partials/update-password-form.blade.php
@@ -1,38 +1,36 @@
 <section>
     <header>
-        <h2 class="text-lg font-medium text-gray-900">
-            {{ __('Update Password') }}
+        <h2>
+            パスワードの更新
         </h2>
 
-        <p class="mt-1 text-sm text-gray-600">
-            {{ __('Ensure your account is using a long, random password to stay secure.') }}
+        <p>
+            安全を確保するため、パスワードはできるだけ長く、また推測されにくいものをご利用ください。
         </p>
     </header>
-
-    <form method="post" action="{{ route('password.update') }}" class="mt-6 space-y-6">
+    <form method="post" action="{{ route('password.update') }}">
         @csrf
         @method('put')
-
         <div>
-            <x-input-label for="current_password" :value="__('Current Password')" />
+            <x-input-label for="current_password" :value="__('現在のパスワード　　　')" />
             <x-text-input id="current_password" name="current_password" type="password" class="mt-1 block w-full" autocomplete="current-password" />
             <x-input-error :messages="$errors->updatePassword->get('current_password')" class="mt-2" />
         </div>
 
         <div>
-            <x-input-label for="password" :value="__('New Password')" />
+            <x-input-label for="password" :value="__('新しいパスワード　　　')" />
             <x-text-input id="password" name="password" type="password" class="mt-1 block w-full" autocomplete="new-password" />
             <x-input-error :messages="$errors->updatePassword->get('password')" class="mt-2" />
         </div>
 
         <div>
-            <x-input-label for="password_confirmation" :value="__('Confirm Password')" />
+            <x-input-label for="password_confirmation" :value="__('新しいパスワードを確認')" />
             <x-text-input id="password_confirmation" name="password_confirmation" type="password" class="mt-1 block w-full" autocomplete="new-password" />
             <x-input-error :messages="$errors->updatePassword->get('password_confirmation')" class="mt-2" />
         </div>
 
         <div class="flex items-center gap-4">
-            <x-primary-button>{{ __('Save') }}</x-primary-button>
+            <x-primary-button>{{ __('保存') }}</x-primary-button>
 
             @if (session('status') === 'password-updated')
                 <p

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,11 +1,11 @@
 <section>
     <header>
         <h2 class="text-lg font-medium text-gray-900">
-            {{ __('Profile Information') }}
+            {{ __('プロフィール情報') }}
         </h2>
 
         <p class="mt-1 text-sm text-gray-600">
-            {{ __("Update your account's profile information and email address.") }}
+            {{ __("ここではプロファイルを更新できます。") }}
         </p>
     </header>
 
@@ -18,13 +18,13 @@
         @method('patch')
 
         <div>
-            <x-input-label for="name" :value="__('Name')" />
+            <x-input-label for="name" :value="__('あなたの名前')" />
             <x-text-input id="name" name="name" type="text" class="mt-1 block w-full" :value="old('name', $user->name)" required autofocus autocomplete="name" />
             <x-input-error class="mt-2" :messages="$errors->get('name')" />
         </div>
 
         <div>
-            <x-input-label for="email" :value="__('Email')" />
+            <x-input-label for="email" :value="__('メールアドレス')" />
             <x-text-input id="email" name="email" type="email" class="mt-1 block w-full" :value="old('email', $user->email)" required autocomplete="username" />
             <x-input-error class="mt-2" :messages="$errors->get('email')" />
 
@@ -48,7 +48,7 @@
         </div>
 
         <div class="flex items-center gap-4">
-            <x-primary-button>{{ __('Save') }}</x-primary-button>
+            <x-primary-button>{{ __('保存') }}</x-primary-button>
 
             @if (session('status') === 'profile-updated')
                 <p


### PR DESCRIPTION
tailwindcssを採用していたが、jsのみの採用に変更。
プルダウンによるプロフィール変更とダッシュボードへの移動ボタンは、ロゴボタンとユーザーネームを押すことで表示できるよう変更し、下のボタンは削除。
プロフィール画面は日本語に変更。