### PR TITLE
クイズ作成機能を追加

### DIFF
--- a/app/Http/Controllers/DeckController.php
+++ b/app/Http/Controllers/DeckController.php
@@ -26,8 +26,7 @@ class DeckController extends Controller
         
         $deck->users()->attach(Auth::id());
             // これにより、作成したデッキを作成者が所有
-        
-        return view('home.index');
+        return redirect()->route('deck.list');
     }
     
     public function list()

--- a/app/Http/Controllers/QuizController.php
+++ b/app/Http/Controllers/QuizController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Auth;
+use App\Models\Deck;
+use App\Models\Quiz;
+use Illuminate\Http\Request;
+use App\Http\Requests\QuizRequest;
+
+class QuizController extends Controller
+{
+    public function newquiz($id)
+    {   
+        $deck = Deck::find($id);
+        return view('quiz.newquiz')
+            ->with (['deck' => $deck]);
+    }
+    public function create(Quiz $quiz, Deck $deck)
+    {
+        $quiz = new Quiz();
+        $quiz->deck_id = request('deck_id');
+        $quiz->question_number = request('question_number');
+        $quiz->question = request('question');
+        $quiz->answer = request('answer');
+        $quiz->save();
+        
+        $deck = Deck::find(request('deck_id'));
+        $deck->question_count = $deck->question_count + 1;
+        $deck->new_question_number = $deck->new_question_number + 1;
+        // $deck->deck_name = $deck->deck_name;
+        // $deck->description = $deck->description;
+        // $deck->creator_id = $deck->creator_id;
+        $deck->save();
+        
+        return view('quiz.newquiz')
+            ->with (['deck' => $deck]);
+    }
+}

--- a/app/Http/Requests/ApiRequest.php
+++ b/app/Http/Requests/ApiRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Http\Exceptions\HttpResponseException;
+
+class ApiRequest extends FormRequest
+{
+
+    /**
+     * @Override
+     * 勝手にリダイレクトさせない
+     * @param  \Illuminate\Contracts\Validation\Validator  $validator
+     */
+    protected function failedValidation(Validator $validator)
+    {
+        $data = [
+            'message' => 'The given data was invalid.',
+            'errors'  => $validator->errors()->toArray(),
+        ];
+
+        throw new HttpResponseException(response()->json($data, 200));
+    }
+}

--- a/app/Http/Requests/QuizRequest.php
+++ b/app/Http/Requests/QuizRequest.php
@@ -5,7 +5,7 @@ namespace App\Http\Requests;
 // use Illuminate\Foundation\Http\FormRequest;
 use App\Http\Requests\ApiRequest;
 
-class DeckRequest extends ApiRequest
+class QuizRequest extends ApiRequest
 {
     /**
      * Determine if the user is authorized to make this request.
@@ -22,16 +22,19 @@ class DeckRequest extends ApiRequest
      *
      * @return array<string, mixed>
      */
-    public function rules()
+    public function rules():
     {
         return [
-            // 'deck_name' => 'required',
+            'question' => 'required',
+            'answer' => 'required',
         ];
     }
+    
     public function messages()
     {
         return [
-            // 'deck_name.required' => 'デッキの名前は必須です。',
+            'question.required' => '問題が記入されていません。',
+            'answer.required' => '解答が記入されていません。'
         ];
     }
 }

--- a/app/Models/Deck.php
+++ b/app/Models/Deck.php
@@ -9,18 +9,15 @@ class Deck extends Model
 {
     use HasFactory;
     protected $fillable = [
-        'creater_id',
         'deck_name',
+        'creator_id',
         'description',
+        'question_count',
+        'new_question_number',
     ];
+    
     public function users()
     {
-        return $this->belongsToMany(User::class);
+        return $this->belongsToMany(User::class);  
     }
-    public function getByLimit(int $limit_count = 10)
-    {
-        // 降順に並べ、最大１０の件数制限をかける
-        return $this->orderBy('updated_at', 'DESC')->limit($limit_count)->get();
-    }
-
 }

--- a/app/Models/Quiz.php
+++ b/app/Models/Quiz.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Quiz extends Model
+{
+    use HasFactory;
+    protected $fillable = [
+        'question_number',
+        'question',
+        'answer',
+        'latest_correct',
+        'correct_count',
+        'latest_Error',
+        'error_count',
+        'hidden',
+    ];
+    
+    public function deck(){
+        return $this->belongsTo(Deck::class);  
+    }
+}

--- a/database/migrations/2023_07_31_141626_create_decks_table.php
+++ b/database/migrations/2023_07_31_141626_create_decks_table.php
@@ -20,10 +20,11 @@ return new class extends Migration
             $table->foreignId('creator_id')->constrained('users');
             //作成したユーザーのid
             $table->text('description')->nullable();
-            //デッキについての説明
-            // $table->tinyInteger('quiztype');
-            //クイズのタイプ(時間の関係上、割愛)
-            //1で○×クイズ、2で４択クイズ、3で一問一答の予定
+            //デッキの説明
+            $table->unsignedSmallInteger('question_count')->default(0);
+            //入っている問題の数
+            $table->unsignedSmallInteger('new_question_number')->default(1);
+            //次に作られるクイズのID（問題が入るたびに１増える）
             $table->timestamps();
         });
     }

--- a/database/migrations/2023_08_10_233109_create_quizzes_table.php
+++ b/database/migrations/2023_08_10_233109_create_quizzes_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('quizzes', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('deck_id')->constrained('decks');
+            //紐づくデッキのID（多対一の関係）
+            $table->unsignedSmallInteger('question_number');
+            //所属するデッキ内でのID（基本的に作られた順）
+            $table->string('question');
+            //クイズの問い
+            $table->string('answer');
+            //クイズの答え
+            $table->dateTime('latest_correct')->nullable();
+            //最後に正解した日時
+            $table->unsignedSmallInteger('correct_count')->default(0);
+            //正解回数
+            $table->dateTime('latest_Error')->nullable();
+            //最後に間違えた日時
+            $table->unsignedTinyInteger('error_count')->default(0);
+            //間違い回数            
+            $table->boolean('hidden')->default(false);
+            //trueになると、問題が登場しなくなる
+            $table->timestamps();
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('quizzes');
+    }
+};

--- a/resources/views/deck/list.blade.php
+++ b/resources/views/deck/list.blade.php
@@ -19,11 +19,13 @@
             <th class="deck_table">名前</th>
             <th>説明</th>
             <th>更新日時</th>
+            <th>クイズ数</th>
+            <th>新規クイズを追加</th>
         </tr>
             @forelse($decks as $deck)
                 <tr>
                     <th class="deck_table_name">
-                        <a href= "{{ route('deck.check', $deck->id)}}">
+                        <a href= "{{ route('deck.check',$deck)}}">
                         {{ $deck->deck_name }}
                         </a>
                     </th>
@@ -33,6 +35,15 @@
                     <th class="deck_table_updated_at">
                         {{ $deck->updated_at }}
                     </th>
+                    <th class="deck_table_question_count">
+                        {{ $deck->question_count }}
+                    </th>
+                    <th class="deck_table_newquiz">
+                        <form method = "POST" action = "{{ route('quiz.newquiz',$deck->id) }}">
+                            @csrf
+                             <button class="create-button">追加</button>
+                        </form>
+                    </th>   
                 </tr>
             </tr>
             @empty

--- a/resources/views/quiz/newquiz.blade.php
+++ b/resources/views/quiz/newquiz.blade.php
@@ -1,0 +1,37 @@
+<x-app-layout>
+    <x-slot name="title">
+        Re_M New Quiz
+    </x-slot>
+    <x-slot name="stylesheet">
+        style.css
+    </x-slot>
+    <x-slot name="header">
+        Re_M {{$deck->deck_name}}の新しいクイズを作る
+    </x-slot>
+    <form method = "POST" action="{{ route('quiz.create') }}">
+        @csrf
+        <input type = "hidden" name = "deck_id" value = {{$deck->id}}>
+        <input type = "hidden" name = "question_number" value = {{$deck->new_question_number}}>
+        <div>
+            <label>
+                クイズの問い
+                <input type = "text" name = "question" value = "{{ old('question') }}">
+            </label>
+            @error('question')
+                <div class="error">{{ $message }}</div>
+            @enderror
+        </div>
+        <div>
+            <label>
+                クイズの解答
+                <input type = "text" name = "answer" value = "{{ old('answer') }}">
+            </label>
+            @error('answer')
+                <div class="error">{{ $message }}</div>
+            @enderror
+        </div>
+        <div class = "form-button">
+            <input type="submit" value="作成">
+        </div>
+    </form>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,9 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
-use App\Http\Controllers\UserController;
 use App\Http\Controllers\DeckController;
+use App\Http\Controllers\QuizController;
+use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -16,14 +17,10 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/',[UserController::class, 'home'])
-    ->middleware(['auth', 'verified'])
-    ->name('user.home');
-    
+//DeckController
 Route::get('/deck/newdeck',[DeckController::class, 'newdeck'])
     ->middleware(['auth', 'verified'])
     ->name('deck.newdeck');
-    
 Route::post('/deck/create',[DeckController::class, 'create'])
     ->middleware(['auth', 'verified'])
     ->name('deck.create');
@@ -35,6 +32,21 @@ Route::post('/deck/search',[DeckController::class, 'search'])
     ->name('deck.search');
 Route::get('/deck/check',[DeckController::class, 'check'])
     ->name('deck.check');
+    
+//QuizController
+Route::post('/quiz/{id}/newquiz',[QuizController::class, 'newquiz'])
+    ->middleware(['auth', 'verified'])
+    ->name('quiz.newquiz');
+Route::post('/quiz/create',[QuizController::class, 'create'])
+    ->middleware(['auth', 'verified'])
+    ->name('quiz.create');
+    
+//UserController
+Route::get('/',[UserController::class, 'home'])
+    ->middleware(['auth', 'verified'])
+    ->name('user.home');
+    
+
 Route::get('/dashboard', function () {
     return view('dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');


### PR DESCRIPTION
list.blade.phpからデッキのIDのみを渡し、コントローラー内でfindにより対象のデッキを呼び出し。
デッキの中に、question_countとnew_question_numberを追加。
分けた理由は、クイズを削除しても一意の番号を付与できるようにするためである。