### PR TITLE
アバターの設定画面を追加

### DIFF
--- a/app/Http/Controllers/AvatarController.php
+++ b/app/Http/Controllers/AvatarController.php
@@ -49,6 +49,26 @@ class AvatarController extends Controller
         }
         
     }
+    public function edit()
+    {
+        $user_id = Auth::user()->id;
+        $avatar = Avatar::find($user_id);
+        return view('avatar.avatar_edit')
+            ->with(["avatar" => $avatar]);
+    }
+    public function update(avatarRequest $request)
+    {
+        $user_id = Auth::user()->id;
+        $avatar = Avatar::find($user_id);
+        $avatar->avatar_name = $request->avatar_name;
+        $avatar->avatar_ID = $request->avatar_ID;
+        $avatar->introduce = $request->introduce;
+        if ($request->searchable === "able"){
+            $avatar->searchable = true;
+        } else {$avatar->searchable = false;}
+        $avatar->save();
+        return redirect()->route('profile.edit');
+    }
     public function crew_add($route)
     // 所謂フレンド登録
     {   

--- a/app/Http/Controllers/QuizController.php
+++ b/app/Http/Controllers/QuizController.php
@@ -47,7 +47,6 @@ class QuizController extends Controller
         $quiz->question = request('question');
         $quiz->answer = request('answer');
         $quiz->save();
-        print_r($quiz);
         $id = $quiz->deck_id;
         return redirect()->route('deck.check', $id);
     }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -6,6 +6,10 @@ body {
     Meiryo,
     sans-serif;
 }
+/*a {*/
+/*  padding:32px;*/
+/*  margin: 32px;*/
+/*}*/
 .deck_tablehead_name{
   width:160px;
 }

--- a/resources/views/avatar/avatar_edit.blade.php
+++ b/resources/views/avatar/avatar_edit.blade.php
@@ -1,23 +1,21 @@
 <x-app-layout>
     <x-slot name="title">
-        Re_M New Avatar
+        Re_M Avatar Update
     </x-slot>
     <x-slot name="stylesheet">
         style.css
     </x-slot>
     <x-slot name="header">
-        Re_M アバターを作成
+        Re_M アバター設定変更
     </x-slot>
-    <main>
-    <p>
-    デッキを共有するためには、オンライン上でのあなたのプロフィールであるアバターの作成が必須です。   
-    </p>
-    <form method = "POST" action="{{ route('avatar.create',$route)}}">
+    <x-slot name="slot">
+        <h1>ここではアバターのプロフィールを更新できます。</h1>
+        <form method = "POST" action="{{ route('avatar.update')}}">
         @csrf
         <div>
             <label>
                 アバターの名前
-                <input type = "text" name = "avatar_name" value = "{{ old('avatar_name') }}">
+                <input type = "text" name = "avatar_name" value = "{{ $avatar->avatar_name }}">
             </label>
             @error('avatar_name')
                 <div class="error">{{ $message }}</div>
@@ -26,7 +24,7 @@
         <div>
             <label>
                 アバターのID（ほかの人があなたのアバターを検索する際に必要です）
-                <input type = "text" name = "avatar_ID" value = "{{ old('avatar_ID') }}">
+                <input type = "text" name = "avatar_ID" value = "{{ $avatar->avatar_ID }}">
             </label>
             @error('avatar_ID')
                 <div class="error">{{ $message }}</div>
@@ -35,7 +33,7 @@
         <div>
             <label>
                 自己紹介文（省略可）
-                <textarea name = "introduce">{{ old('introduce') }}</textarea>
+                <textarea name = "introduce">{{ $avatar->introduce }}</textarea>
             </label>
             @error('introduce')
                 <div class="error">{{ $message }}</div>
@@ -50,5 +48,5 @@
             <input type="submit" value="作成">
         </div>
     </form>
-    </main>
+    </x-slot>
 </x-app-layout>

--- a/resources/views/profile/partials/update-profile-information-form.blade.php
+++ b/resources/views/profile/partials/update-profile-information-form.blade.php
@@ -1,12 +1,12 @@
 <section>
     <header>
-        <h2 class="text-lg font-medium text-gray-900">
+        <h2>
             {{ __('プロフィール情報') }}
         </h2>
-
         <p class="mt-1 text-sm text-gray-600">
-            {{ __("ここではプロファイルを更新できます。") }}
+            {{ __("ここではプロフィールを更新できます。") }}
         </p>
+        <a class = "m-2"href = "/avatar/edit">アバターの設定はこちら</a>
     </header>
 
     <form id="send-verification" method="post" action="{{ route('verification.send') }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -26,12 +26,17 @@ Route::middleware(['auth', 'verified'])->group(function() {
         ->name('avatar.newavatar');
     Route::post('/avatar/create/{route}',[AvatarController::class, 'create'])
         ->name('avatar.create');
+    Route::get('/avatar/edit',[AvatarController::class, 'edit'])
+        ->name('avatar.edit');
+    Route::post('/avatar/update',[AvatarController::class, 'update'])
+        ->name('avatar.update');
     Route::get('/crew/add/{route}',[AvatarController::class, 'crew_add'])
         ->name('crew.add');
     Route::post('/crew/register/{route}',[AvatarController::class, 'crew_register'])
         ->name('crew.register');
     Route::get('/group/avatar',[AvatarController::class, 'group_avatar_exist'])
         ->name('group.avatar.exist');
+    
 });
     
 


### PR DESCRIPTION
プロフィールの変更画面から遷移可能。
avatar_IDのユニーク設定のため、同じIDのまま変更しようとするとエラーになる。
改善が必要。